### PR TITLE
Why setting midpoint instead of closing?

### DIFF
--- a/YoolaxWindowBlinds.groovy
+++ b/YoolaxWindowBlinds.groovy
@@ -191,10 +191,10 @@ def close() {
     def currentLevel = device.currentValue("deviceLevel")
     if(currentLevel == closeLevel) {
         if (descTextOutput) log.info "Blinds are already Fully Closed."
-    } else if(currentLevel == midLevel) {
-        hardClose()
-    } else if(currentLevel > closeLevel) {
-        setMidpoint()
+//    } else if(currentLevel == midLevel) {
+//        hardClose()
+//    } else if(currentLevel > closeLevel) {
+//        setMidpoint()
     } else {
         hardClose()
     }


### PR DESCRIPTION
I had an automation messed up and figured out the lines 196 and 197 were the issue. I don't know if there is a reason for them. Then I also removed the check for midlevel because it's the same scenario as not closed, isn't?